### PR TITLE
ci: fix spurious SC3054 from the hadolint 2.15.x shell-tracking regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,14 @@ ENV GPSD_DEVICES="/dev/gps"
 ENV GPSD_USBAUTO="true"
 ENV GPSD_SOCKET="/var/run/gpsd.sock"
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG VERSION_REPO="sdr-enthusiasts/docker-aprs-tracker" \
     VERSION_BRANCH="##BRANCH##"
+
+# SHELL must come *after* any ARG/ENV in the stage. hadolint 2.15.x resets its
+# shell-dialect tracking to POSIX sh when an ARG or ENV follows SHELL, which
+# makes every later RUN be linted as sh and spuriously reports SC3054 for the
+# bash arrays below.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN --mount=type=bind,from=gpsd-build,source=/,target=/gpsd-build/ \
     set -x && \


### PR DESCRIPTION
## Problem

hadolint 2.15.x resets its shell-dialect tracking to POSIX sh when an `ARG` or `ENV` appears **after** `SHELL` in the same stage. Every subsequent `RUN` is then linted as `sh`, so the bash arrays in the install `RUN` are reported as undefined:

```console
$ hadolint --config <shared ruleset> Dockerfile     # 2.14.0, the flake.lock pin
rc=0

$ hadolint --config <shared ruleset> Dockerfile     # 2.15.1
Dockerfile:26 SC3054 warning: In POSIX sh, array references are undefined.
rc=1
```

This is an upstream regression, not a real portability problem — that `RUN` executes under bash via the `SHELL` directive. Minimal reproduction:

```dockerfile
FROM debian:trixie-slim
SHELL ["/bin/bash", "-o", "pipefail", "-c"]
ARG FOO="bar"
RUN P=() && P+=(nginx) && echo "${P[@]}"
```

```text
2.15.1 -> SC3054 warning: In POSIX sh, array references are undefined.
2.14.0 -> rc=0
```

`check_docker` is already `true` here, so this is a latent `Lint` failure on every PR the moment a `flake.lock` bump lands 2.15.x. This repo has **no `HEALTHCHECK`**, so unlike most of this series it is unaffected by the `DL3025` extension — the SC3054 regression is the only finding.

## Changes

```diff
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG VERSION_REPO="sdr-enthusiasts/docker-aprs-tracker" \
     VERSION_BRANCH="##BRANCH##"
+
+# SHELL must come *after* any ARG/ENV in the stage. hadolint 2.15.x resets its
+# shell-dialect tracking to POSIX sh when an ARG or ENV follows SHELL, which
+# makes every later RUN be linted as sh and spuriously reports SC3054 for the
+# bash arrays below.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
```

The reorder is **inert**: `ARG` scope runs from its declaration to the end of the stage either way, and `SHELL` does not consume it. Confirmed `--build-arg` propagates identically with the declaration on either side of `SHELL`.

This repo already re-issues `SHELL` later in the file (line 78), so keeping `SHELL` adjacent to the `RUN`s it governs is a pre-existing pattern here.

### Why not `# hadolint ignore=SC3054`

A pragma would suppress the whole POSIX-portability rule class on that `RUN` and hide genuine findings. The blast radius of the upstream bug is also wider than SC3054 — the same reset makes `SC3010`, `SC3009`, `SC3014`, `SC3028` and `SC3037` misfire:

```text
construct           2.14.0   2.15.1
bash array          clean    SC3054
[[ -f x ]]          clean    SC3010
[[ a == b ]]        clean    SC3014
echo {a,b}          clean    SC3009
$RANDOM             clean    SC3028
echo -e             clean    SC3037
```

Fixing the ordering closes all of them at once.

## Verification

- hadolint clean at **2.14.0** (the current `flake.lock` pin) and **2.15.1** (current `:latest`)
- `nix develop -c pre-commit run --all-files`: green, all hooks Passed or Skipped
- `docker build --platform linux/amd64`: succeeds
- No `HEALTHCHECK` in this image, so no exec-form change and no healthcheck A:B applies. `ENTRYPOINT ["/init"]` is inherited from the base image, already in exec form, so s6 remains PID 1
- No hooks bypassed; no `--no-verify`
